### PR TITLE
Change Go starter package

### DIFF
--- a/app/views/starters.scala.html
+++ b/app/views/starters.scala.html
@@ -32,7 +32,7 @@
       "NodeJS" -> "https://github.com/ozten/vindinium-starter-nodejs",
       "F#" -> "https://github.com/Rickasaurus/FSVindinium",
       "C#" -> "https://github.com/ozten/vindinium-starter-csharp",
-      "Go" -> "https://github.com/Gybes/vindinium-starter-go").sortBy(_._1).map {
+      "Go" -> "https://github.com/geetarista/vindinium-starter-go").sortBy(_._1).map {
       case (lang, url) => {
       <p>
         <a href="@url">


### PR DESCRIPTION
I'd like to change the Go starter for the following reasons:
1. Idiomatic Go: this package adheres to the standards and style of the Go language.
2. Tests: these help reinforce the integrity of the game logic and client.
3. Game logic: includes more of the structure and ideas found in the [Python starter](https://github.com/ornicar/vindinium-starter-python).
4. Client complete: provides all options available when running in either arena or game mode.

https://github.com/geetarista/vindinium-starter-go
