### PR TITLE
Fix player 1 getting extra turn at end of game.

### DIFF
--- a/app/Game.scala
+++ b/app/Game.scala
@@ -28,7 +28,7 @@ case class Game(
 
   def step = if (finished) this else {
     val next = copy(turn = turn + 1)
-    if (next.turn > maxTurns) next.copy(status = Status.TurnMax) else next
+    if (next.turn >= maxTurns) next.copy(status = Status.TurnMax) else next
   }
 
   def setTimedOut = hero match {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -113,13 +113,13 @@ function runGame (mount, gameId) {
 
   function play () {
     if (playing) return;
-    restart(!game || game.turn-1 === game.maxTurns ? 1 : game.turn);
+    restart(!game || game.turn === game.maxTurns ? 1 : game.turn);
     render();
   }
 
   function jump (turn) {
     turn -= 1;
-    if (turn < 0 || game && turn > game.maxTurns) return;
+    if (turn < 0 || game && turn >= game.maxTurns) return;
     gameInterruptions.onNext("jumped");
     gameStream
       .skip(turn)

--- a/client/src/ui/TurnCount/index.js
+++ b/client/src/ui/TurnCount/index.js
@@ -9,7 +9,7 @@ var TurnCount = React.createClass({
   render: function(){
     var game = this.props.game;
     // var number = Math.floor((game.turn+ 1) / 4) + '/' + Math.ceil(game.maxTurns/4);
-    var number = (game.turn-1) + '/' + game.maxTurns;
+    var number = (game.turn) + '/' + game.maxTurns;
     return <div className="turn-count">
       <div className="legend">
         <strong>Turn</strong>


### PR DESCRIPTION
Fix a bug where player 1 would get an extra turn at the end of the
game due to an off-by-one-error. Also update the front-end to
match, so that the final turn still displays as, e.g., 1200/1200
instead of 1199/1200.

The bug can be observed most easily by starting a training game
with number-of-turns set to 1, and observing your own bot move
twice, but occurs in arena matches as well.
