### PR TITLE
Add an optional field 'lastDir', storing each hero's last order

### DIFF
--- a/app/Arbiter.scala
+++ b/app/Arbiter.scala
@@ -24,7 +24,7 @@ object Arbiter {
 
   private def doMove(game: Game, id: Int, dir: Dir) = {
 
-    def reach(destPos: Pos) = (game.board get destPos) match {
+    def reach(game: Game, destPos: Pos) = (game.board get destPos) match {
       case None => game
       case Some(tile) => (game hero destPos) match {
         case Some(_) => game
@@ -42,7 +42,10 @@ object Arbiter {
     }
 
     if (dir == Dir.Crash) finalize(game.setTimedOut, id).step
-    else finalize(fights(reach(game.hero(id).pos to dir), id), id).step
+    else {
+      val h = game.hero(id).withLastDir(dir)
+      finalize(fights(reach(game.withHero(h), h.pos to dir), id), id).step
+    }
   }
 
   private def reSpawn(game: Game, h: Hero, rec: Int = 0): Game = {

--- a/app/Hero.scala
+++ b/app/Hero.scala
@@ -7,6 +7,7 @@ case class Hero(
     userId: Option[String],
     elo: Option[Int],
     pos: Pos,
+    lastDir: Option[Dir],
     life: Int,
     gold: Int,
     timedOut: Boolean,
@@ -21,6 +22,8 @@ case class Hero(
   def defend = withLife(Hero.defendLife)
 
   def fightMine = withLife(Hero.mineLife)
+
+  def withLastDir(dir: Dir) = copy(lastDir = Some(dir))
 
   def withLife(diff: Int) = copy(life = math.max(0, math.min(Hero.maxLife, life + diff)))
 
@@ -53,6 +56,7 @@ object Hero {
     userId = userId,
     elo = elo,
     pos = pos,
+    lastDir = None,
     life = maxLife,
     gold = 0,
     timedOut = false)

--- a/app/JsonFormat.scala
+++ b/app/JsonFormat.scala
@@ -34,6 +34,13 @@ object JsonFormat {
     "userId" -> h.userId,
     "elo" -> h.elo,
     "pos" -> apply(h.pos),
+    "lastDir" -> h.lastDir.map {
+        case Dir.North => "North"
+        case Dir.South => "South"
+        case Dir.East  => "East"
+        case Dir.West  => "West"
+        case _         => "Stay"
+    },
     "life" -> h.life,
     "gold" -> h.gold,
     "mineCount" -> g.board.countMines(h.id),

--- a/app/views/starters.scala.html
+++ b/app/views/starters.scala.html
@@ -207,6 +207,7 @@
                "x":4,
                "y":8
             },
+            "lastDir": "South",
             "life":38,
             "gold":1078,
             "mineCount":6,
@@ -232,6 +233,7 @@
          "x":4,
          "y":8
       },
+      "lastDir": "South",
       "life":38,
       "gold":1078,
       "mineCount":6,
@@ -279,6 +281,7 @@
                "x":5,
                "y":6
             },
+            "lastDir": "South",
             "life":60,
             "gold":0,
             "mineCount":0,
@@ -288,7 +291,7 @@
             },
             "crashed":true
          }</pre>
-          <p>Nothing special here, <strong>pos</strong> represents your initial position on the map. <strong>spawnPos</strong> represents the position where you will respawn when you die. For now, it's the same position. <strong>elo</strong> is the current rating of the player (the higher the better).</p>
+          <p>Nothing special here, <strong>pos</strong> represents your initial position on the map. <strong>spawnPos</strong> represents the position where you will respawn when you die. For now, it's the same position. <strong>elo</strong> is the current rating of the player (the higher the better). <strong>lastDir</strong> is the last order this hero issued (if any).</p>
           <h3 id="json-url">Urls</h3>
 
           <pre>


### PR DESCRIPTION
Hi. So, due to heroes being teleported upon their deaths (which can trigger more deaths and more teleportation) it can be hard for an AI to determine exactly how the opponents moved. Since this data is readily available to the server, I request to add it to the player input in the form of "lastDir" field that records hero's last order (as one of the "North", "East", "South", "West" and "Stay" strings).

I've tested the patch locally, and it seems to produce the correct data in both player input and the events stream.
