### PR TITLE
Modify ELO "k" factor

### DIFF
--- a/app/system/Elo.scala
+++ b/app/system/Elo.scala
@@ -42,9 +42,9 @@ final class Elo extends Actor with ActorLogging {
       val expected = 1 / (1 + math.pow(10, (opponent.elo - player.elo) / 400f))
       val kFactor = math.round(
         if (player.nbGames > 20) 16
-        else 50 - player.nbGames * (34 / 20f)
+        else 100 - player.nbGames * (21 / 5f)
       )
-      val diff = 2 * kFactor * (player.score(opponent) - expected)
+      val diff = kFactor * (player.score(opponent) - expected)
       // println(s"$player vs $opponent = ${diff.toInt}")
       diff.toInt
     }


### PR DESCRIPTION
The elo ratings of most bots fluctuate by around 250 points even when
just playing constantly without being modified. In the IRC chat on
September 30 multiple users expressed support for lowering the k factor
to lower the volatility of the bots' elos. This changes the k factor
for experienced bots from 32 to 16 and rescales the k factor for new
bots so that it gradually descends from 100 to 16 rather than 100 to 32
like it used to before.

Based on some test code I wrote at http://pastebin.com/sX0uaqzK, if four
bots of exactly even strength played each other for one day (which is
around 420 games), then with a k factor of 32 their elo range
would be around 350 points, whereas with a k factor of 16 their elo
range is around 220 points. Since not all bots are of even strength on
Vindinium, this should be less in practice. Meanwhile, a k factor of 16
is still large enough to allow plently of upward mobility for a bot that
improves and starts winning more games than its rating predicts.
