### PR TITLE
Fix "Path must be a string" issue with jslint

### DIFF
--- a/client/Gruntfile.js
+++ b/client/Gruntfile.js
@@ -14,7 +14,8 @@ module.exports = function (grunt) {
     jshint: {
       options: {
         jshintrc: ".jshintrc",
-        convertJSX: true
+        convertJSX: true,
+        reporterOutput: ""
       },
       src: ['src/**/*.js']
     },


### PR DESCRIPTION
Fix build issue with latest jslint